### PR TITLE
Add static site build and deploy workflows

### DIFF
--- a/.github/workflows/deploy_static.yaml
+++ b/.github/workflows/deploy_static.yaml
@@ -1,0 +1,57 @@
+name: Deploy Static
+
+on:
+    # Run this workflow from other workflows
+    workflow_call:
+      inputs:
+        source:
+          description: 'Source package'
+          required: true
+          type: string
+        target:
+          description: 'Path to target folder'
+          required: true
+          type: string
+      secrets:
+        creds:
+          required: true
+
+jobs:
+  deploy_static:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Download source
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ inputs.source }}
+
+    - uses: azure/login@v1
+      with:
+          creds: ${{ secrets.creds }}
+
+    - name: Upload to blob storage
+      id: upload
+      uses: azure/CLI@v1
+      with:
+        inlineScript: |
+            az storage blob upload \
+              --account-name zooniversestatic \
+              --content-cache-control 'public, max-age=60' \
+              --container-name '$web' \
+              --name '${{ inputs.target }}/index.html' \
+              --file './index.html'
+            rm ./index.html
+            az storage blob upload \
+              --account-name zooniversestatic \
+              --content-cache-control 'public, max-age=60' \
+              --container-name '$web' \
+              --name '${{ inputs.target }}/commit_id.txt' \
+              --file './commit_id.txt'
+            rm ./commit_id.txt
+            az storage blob upload-batch \
+              --account-name zooniversestatic \
+              --content-cache-control 'public, immutable, max-age=604800' \
+              --destination '$web/${{ inputs.target }}' \
+              --source ./

--- a/.github/workflows/deploy_static.yaml
+++ b/.github/workflows/deploy_static.yaml
@@ -1,20 +1,20 @@
 name: Deploy Static
 
 on:
-    # Run this workflow from other workflows
-    workflow_call:
-      inputs:
-        source:
-          description: 'Source package'
-          required: true
-          type: string
-        target:
-          description: 'Path to target folder'
-          required: true
-          type: string
-      secrets:
-        creds:
-          required: true
+  # Run this workflow from other workflows
+  workflow_call:
+    inputs:
+      source:
+        description: 'Source package'
+        required: true
+        type: string
+      target:
+        description: 'Path to target folder'
+        required: true
+        type: string
+    secrets:
+      creds:
+        required: true
 
 jobs:
   deploy_static:
@@ -29,29 +29,29 @@ jobs:
 
     - uses: azure/login@v1
       with:
-          creds: ${{ secrets.creds }}
+        creds: ${{ secrets.creds }}
 
     - name: Upload to blob storage
       id: upload
       uses: azure/CLI@v1
       with:
         inlineScript: |
-            az storage blob upload \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, max-age=60' \
-              --container-name '$web' \
-              --name '${{ inputs.target }}/index.html' \
-              --file './index.html'
-            rm ./index.html
-            az storage blob upload \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, max-age=60' \
-              --container-name '$web' \
-              --name '${{ inputs.target }}/commit_id.txt' \
-              --file './commit_id.txt'
-            rm ./commit_id.txt
-            az storage blob upload-batch \
-              --account-name zooniversestatic \
-              --content-cache-control 'public, immutable, max-age=604800' \
-              --destination '$web/${{ inputs.target }}' \
-              --source ./
+          az storage blob upload \
+            --account-name zooniversestatic \
+            --content-cache-control 'public, max-age=60' \
+            --container-name '$web' \
+            --name '${{ inputs.target }}/index.html' \
+            --file './index.html'
+          rm ./index.html
+          az storage blob upload \
+            --account-name zooniversestatic \
+            --content-cache-control 'public, max-age=60' \
+            --container-name '$web' \
+            --name '${{ inputs.target }}/commit_id.txt' \
+            --file './commit_id.txt'
+          rm ./commit_id.txt
+          az storage blob upload-batch \
+            --account-name zooniversestatic \
+            --content-cache-control 'public, immutable, max-age=604800' \
+            --destination '$web/${{ inputs.target }}' \
+            --source ./

--- a/.github/workflows/npm_build.yaml
+++ b/.github/workflows/npm_build.yaml
@@ -1,0 +1,56 @@
+name: NPM build
+
+on:
+  # Run this workflow from other workflows
+  workflow_call:
+    inputs:
+      commit_id:
+        description: 'HEAD commit hash'
+        required: true
+        type: string
+      node_version:
+        default: '14.x'
+        description: 'Node version'
+        required: false
+        type: string
+      script:
+        description: 'npm build script'
+        required: true
+        type: string
+      output:
+        description: 'Output directory name'
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HEAD_COMMIT: ${{ inputs.commit_id }}
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache dependencies
+      uses: actions/cache@v1
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - name: Node.js build
+      id: build
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ inputs.node_version }}
+    - run: npm ci
+    - run: npm run ${{ inputs.script }}
+
+    - name: Write commit_id.txt
+      run: echo ${HEAD_COMMIT} > ./${{ inputs.output }}/commit_id.txt
+
+    - name: Save build
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ inputs.output }}
+        path: ./${{ inputs.output }}/


### PR DESCRIPTION
Adds npm_build.yaml and deploy_static.yaml, reusable workflows for building, storing, and deploying npm-built static sites. This process was modeled on PFE, where the result of `npm build` is stored as an artifact, which is then picked up by the deploy workflow and pushed out via `az` to blob storage. I believe this means the context of a given artifact is the action itself, so there won't be collisions.

These should work for PFE (that's the point here), but I'm planning on test on data.galaxyzoo.org. That's kind of an older site, but it uses npm and needs to deploy to blob storage just like everything else. 