### PR TITLE
Upgrade to actions/setup-node@v2

### DIFF
--- a/.github/workflows/npm_build.yaml
+++ b/.github/workflows/npm_build.yaml
@@ -30,19 +30,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Cache dependencies
-      uses: actions/cache@v1
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-
     - name: Node.js build
       id: build
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ inputs.node_version }}
+        cache: 'npm'
     - run: npm ci
     - run: npm run ${{ inputs.script }}
 


### PR DESCRIPTION
Upgrade to `actions/setup-node@v2`, which includes npm package caching. Remove the separate caching step.