### PR TITLE
Use an input with a default for max-age non-index files

### DIFF
--- a/.github/workflows/deploy_static.yaml
+++ b/.github/workflows/deploy_static.yaml
@@ -12,6 +12,11 @@ on:
         description: 'Path to target folder'
         required: true
         type: string
+      max_age:
+        description: 'max-age for non-index.html files'
+        default: 604800
+        required: false
+        type: string
     secrets:
       creds:
         required: true
@@ -52,6 +57,6 @@ jobs:
           rm ./commit_id.txt
           az storage blob upload-batch \
             --account-name zooniversestatic \
-            --content-cache-control 'public, immutable, max-age=604800' \
+            --content-cache-control 'public, immutable, max-age=${{ inputs.max_age }}' \
             --destination '$web/${{ inputs.target }}' \
             --source ./


### PR DESCRIPTION
Add optional input to blob storage deployments to set the max-age of all files not called index.html (which stays at 60s).