### PR TITLE
Use one-line no-focus check, not a script, for rspec running

### DIFF
--- a/.github/workflows/run_rspec.yaml
+++ b/.github/workflows/run_rspec.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check for focused specs
-        run: ./scripts/no_focus.sh
+        run: ! grep -R "\(describe\|context\|it\).*\(:focus\|focus:\)" spec/
 
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
A Rails repo might not include a no-focus script, but that check should still be run when running the tests. Since it's just one line, put it in the shared spec runner.