### PR TITLE
Use SHA instead of deployed image tag for DB migrations

### DIFF
--- a/.github/workflows/db_migration.yaml
+++ b/.github/workflows/db_migration.yaml
@@ -12,6 +12,10 @@ on:
         description: 'environment to affect'
         required: true
         type: string
+      commit_id:
+        description: 'HEAD commit hash'
+        required: true
+        type: string
     secrets:
       creds:
         required: true
@@ -32,12 +36,11 @@ jobs:
 
       - name: Set environment variables
         run: |
-          echo "DEPLOYED_IMAGE_TAG=$(kubectl get deployment ${{ inputs.app_name }}-${{ inputs.environment }}-app -o=jsonpath='{$.spec.template.spec.containers[:1].image}' | cut -d':' -f 2)" >> $GITHUB_ENV
           echo "JOB_NAME=${{ inputs.app_name }}-db-migration-${{ inputs.environment }}-${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Modify & apply template
         run: |
-          sed "s/__IMAGE_TAG__/$DEPLOYED_IMAGE_TAG/g" ./kubernetes/db-migrate-${{ inputs.environment }}.tmpl \
+          sed "s/__IMAGE_TAG__/${{ inputs.commit_id }}/g" ./kubernetes/db-migrate-${{ inputs.environment }}.tmpl \
             | sed "s/__JOB_NAME__/$JOB_NAME/g" \
             | kubectl apply -f -
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ jobs:
       ruby_version: 2.6.5
 ```
 
+### Deploy a Rails app in Kubernetes
+```yaml
+  deploy_staging:
+    name: Deploy to Staging
+    uses: zooniverse/ci-cd/.github/workflows/deploy_app.yaml@main
+    with:
+      app_name: myapp
+      repo_name: myapp
+      commit_id: ${{ github.sha }}
+      environment: staging
+    secrets:
+      creds: ${{ secrets.AZURE_AKS }}
+```
+
 ### Build and deploy a static site
 ```yaml
 name: Deploy App to Production


### PR DESCRIPTION
Prevent a race condition where the "push to master" event fires both the DB Migration and Deploy to Staging workflows at the same time. The Deploy workflow builds and pushes the new image to GHCR, then deploys that image to Kubernetes. Currently, the Migration job uses the Run Task method of determining the currently deployed tag from the k8s pod, then instantiates a new pod based on that image to run the job. However, this will be the old, previously-deployed commit if the deploy job doesn't finish first, which it probably won't.

Now, the same commit id being used to build and push the new image is also passed to the Migration job and used to create the job pod. It's possible that this still doesn't fly because the image with that tag doesn't exist in GHCR until the Deploy job is done. If that fails instead of trying until it succeeds, then I'll have to build the new image in the PR update step, after all.