### PR TITLE
Add newly-required --overwrite flag to az uploads

### DIFF
--- a/.github/workflows/deploy_static.yaml
+++ b/.github/workflows/deploy_static.yaml
@@ -44,6 +44,7 @@ jobs:
           az storage blob upload \
             --account-name zooniversestatic \
             --content-cache-control 'public, max-age=60' \
+            --overwrite \
             --container-name '$web' \
             --name '${{ inputs.target }}/index.html' \
             --file './index.html'
@@ -51,6 +52,7 @@ jobs:
           az storage blob upload \
             --account-name zooniversestatic \
             --content-cache-control 'public, max-age=60' \
+            --overwrite \
             --container-name '$web' \
             --name '${{ inputs.target }}/commit_id.txt' \
             --file './commit_id.txt'
@@ -58,5 +60,6 @@ jobs:
           az storage blob upload-batch \
             --account-name zooniversestatic \
             --content-cache-control 'public, immutable, max-age=${{ inputs.max_age }}' \
+            --overwrite \
             --destination '$web/${{ inputs.target }}' \
             --source ./


### PR DESCRIPTION
New `az` client version 2.34.0 introduced a breaking change wherein the previous default of "overwrite" was changed to "throw an error instead of overwrite if the new --overwrite flag is not included".

https://docs.microsoft.com/en-us/cli/azure/release-notes-azure-cli#storage

This overwrite-by-default behavior was expected by this action, and so now specifies the `--overwrite` flag explicitly.