### PR TITLE
Pin az CLI version to 2.33.1

### DIFF
--- a/.github/workflows/deploy_static.yaml
+++ b/.github/workflows/deploy_static.yaml
@@ -40,6 +40,7 @@ jobs:
       id: upload
       uses: azure/CLI@v1
       with:
+        azcliversion: 2.33.1
         inlineScript: |
           az storage blob upload \
             --account-name zooniversestatic \


### PR DESCRIPTION
The azure/CLI action by default uses the `latest` version of the Azure CLI. This is currently not actually happening, as the action pulled 2.33.1, then for a few hours yesterday used 2.34.1, then reverted back to 2.33.1, where it sits right now.

This pins the version to 2.33.1 so that when the update is pushed out again, all our uploads won't fail. The upload tester will run as a check on this PR, and when that update does come, we should be able to use that test workflow to safely update and test our deploy_static workflow prior to making it live for our other sites.