### PR TITLE
Allow optional inclusion of --build-args to Docker

### DIFF
--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -17,6 +17,11 @@ on:
         required: false
         default: false
         type: boolean
+      build_args:
+        description: 'build-args to docker'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   build_and_push_image:
@@ -52,5 +57,6 @@ jobs:
         context: .
         push: true
         tags: ${{ steps.create_tags.outputs.tag }}
+        build-args: ${{ inputs.build_args }}
         cache-from: type=gha
         cache-to: type=gha,mode=max


### PR DESCRIPTION
Not required, and defaults to an empty string if not provided.