### PR TITLE
Remove checkout from static deploys

### DIFF
--- a/.github/workflows/deploy_static.yaml
+++ b/.github/workflows/deploy_static.yaml
@@ -25,8 +25,6 @@ jobs:
   deploy_static:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-
     - name: Download source
       uses: actions/download-artifact@v2
       with:


### PR DESCRIPTION
Static deploys should only deploy the downloaded build, not the entire source code and Git history.

Closes #23.