### PR TITLE
add dockerfile input variable

### DIFF
--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -12,6 +12,11 @@ on:
         description: 'HEAD commit hash'
         required: true
         type: string
+      file:
+        description: 'The dockerfile to build the image against'
+        required: false
+        default: 'Dockerfile'
+        type: string
       latest:
         description: 'Tag the image with latest?'
         required: false
@@ -55,6 +60,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
+        file: ${{ inputs.file }}
         push: true
         tags: ${{ steps.create_tags.outputs.tag }}
         build-args: ${{ inputs.build_args }}


### PR DESCRIPTION
Based on https://github.com/docker/build-push-action#inputs

This PR adds the ability to specify the dockerfile as an input to the build and push action. It preserves the default value of `Dockerfile` for backwards compatibility with the action