### PR TITLE
add ci_args to npm ci run cmd

### DIFF
--- a/.github/workflows/npm_build.yaml
+++ b/.github/workflows/npm_build.yaml
@@ -17,6 +17,11 @@ on:
         description: 'npm build script'
         required: true
         type: string
+      ci_args:
+        default: ''
+        description: 'npm ci args'
+        required: false
+        type: string
       output:
         description: 'Output directory name'
         required: true
@@ -36,7 +41,7 @@ jobs:
       with:
         node-version: ${{ inputs.node_version }}
         cache: 'npm'
-    - run: npm ci
+    - run: npm ci ${{ inputs.ci_args }}
     - run: npm run ${{ inputs.script }}
 
     - name: Write commit_id.txt


### PR DESCRIPTION
fixes #32 allow us to pass explicit args to npm ci cmd, e.g. `npm ci --legacy-peer-deps`

I wasn't sure how to best handle this with say an optional boolean input (default to false) that turns on this specific behaviour to limit the scope of what can be passed to `npm ci` cmd (non trivial and complicated the action setup. So i chose the allow any flag to flow through via the args string input which will allow us to morph the npm ci behaviours as required. Happy to revisit if folks think this is too open

details on the args we can pass to `npm ci`
- https://docs.npmjs.com/cli/v7/commands/npm-install#configuration
- https://docs.npmjs.com/cli/v7/commands/npm-ci#synopsis