### PR TITLE
add --ignore-scripts to npm build

### DIFF
--- a/.github/workflows/npm_build.yaml
+++ b/.github/workflows/npm_build.yaml
@@ -36,7 +36,7 @@ jobs:
       with:
         node-version: ${{ inputs.node_version }}
         cache: 'npm'
-    - run: npm ci
+    - run: npm ci --ignore-scripts
     - run: npm run ${{ inputs.script }}
 
     - name: Write commit_id.txt


### PR DESCRIPTION
Related to https://github.com/zooniverse/ci-cd/pull/33#issuecomment-1268040406

Run `npm ci` system with `--ignore-scripts` to secure the npm builds from package supply chain attacks via shell access in pre / post scripts. See https://docs.npmjs.com/cli/v7/commands/npm-install#ignore-scripts

