### PR TITLE
Update download-artifact to v3

### DIFF
--- a/.github/workflows/deploy_static.yaml
+++ b/.github/workflows/deploy_static.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download source
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ${{ inputs.source }}
 


### PR DESCRIPTION
Dependabot version of this doesn't seem to inherit the permissions required to run the tests. Opening this myself to test the tests.