### PR TITLE
Update docker login-action to v2

### DIFF
--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -38,7 +38,7 @@ jobs:
         repository: zooniverse/${{ inputs.repo_name }}
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/workflows/deploy_app.yaml
+++ b/.github/workflows/deploy_app.yaml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/checkout@v3.1.0
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.actor }}


### PR DESCRIPTION
Testing the hypothesis that some tests are failing due to @dependabot not having the necessary permissions to push to GHCR. This is probably good practice, so if it turns out to be true there may be some tweaking necessary to run tests without that bit.