### PR TITLE
Update deprecated set-output syntax

### DIFF
--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -53,7 +53,7 @@ jobs:
         tag="ghcr.io/zooniverse/${{ inputs.repo_name }}:${{ inputs.commit_id }}"
         if [ "${{ inputs.latest }}" = true ]; then tag="$tag,ghcr.io/zooniverse/${{ inputs.repo_name }}:latest"; fi
         echo $tag
-        echo "{tag}={$tag}" >> $GITHUB_OUTPUT
+        echo "tag=$tag" >> $GITHUB_OUTPUT
 
     - name: Create commit_id.txt
       run: echo ${{ inputs.commit_id }} > commit_id.txt

--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -53,7 +53,7 @@ jobs:
         tag="ghcr.io/zooniverse/${{ inputs.repo_name }}:${{ inputs.commit_id }}"
         if [ "${{ inputs.latest }}" = true ]; then tag="$tag,ghcr.io/zooniverse/${{ inputs.repo_name }}:latest"; fi
         echo $tag
-        echo ::set-output name=tag::$tag
+        echo "{tag}={$tag}" >> $GITHUB_OUTPUT
 
     - name: Create commit_id.txt
       run: echo ${{ inputs.commit_id }} > commit_id.txt


### PR DESCRIPTION
GHA is deprecating the `set-output` syntax I used to tag docker images. This updates to the new environment var syntax.