### PR TITLE
Bump default NodeJS to 18 LTS

### DIFF
--- a/.github/workflows/npm_build.yaml
+++ b/.github/workflows/npm_build.yaml
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
       node_version:
-        default: '14.x'
+        default: 'lts/hydrogen'
         description: 'Node version'
         required: false
         type: string


### PR DESCRIPTION
Node 14 is End-Of-Life in April 2023. Node 16 became a maintenance release in October 2022 and support ends in September 2023. This PR bumps the default NodeJS to 18 (`lts/hydrogen`),  which is supported until April 2025.