### PR TITLE
Bump actions/checkout from 3.3.0 to 3.5.2

### DIFF
--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3.5.2
       with:
         repository: zooniverse/${{ inputs.repo_name }}
 

--- a/.github/workflows/db_migration.yaml
+++ b/.github/workflows/db_migration.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
 
       - name: Set the target AKS cluster
         uses: Azure/aks-set-context@v1

--- a/.github/workflows/deploy_app.yaml
+++ b/.github/workflows/deploy_app.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3.5.2
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2

--- a/.github/workflows/npm_build.yaml
+++ b/.github/workflows/npm_build.yaml
@@ -28,7 +28,7 @@ jobs:
     env:
       HEAD_COMMIT: ${{ inputs.commit_id }}
     steps:
-    - uses: actions/checkout@v3.3.0
+    - uses: actions/checkout@v3.5.2
 
     - name: Node.js build
       id: build

--- a/.github/workflows/run_rspec.yaml
+++ b/.github/workflows/run_rspec.yaml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
 
       - name: Check for focused specs
         run: ./scripts/no_focus.sh

--- a/.github/workflows/run_task.yaml
+++ b/.github/workflows/run_task.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
 
       - name: Set the target AKS cluster
         uses: Azure/aks-set-context@v1


### PR DESCRIPTION
Same as https://github.com/zooniverse/ci-cd/pull/56.

Actions that run as a result of Dependabot opening a PR do not have access to GITHUB_TOKEN in those actions. Need a less cumbersome way to allow Dependabot PRs to go through CI/CD checks without manually checking out/renaming/`git push --set-upstream origin`ing each of them. TBD.

Bumps [actions/checkout](https://github.com/actions/checkout) from 3.3.0 to 3.5.2.
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v3.3.0...v3.5.2)

---
updated-dependencies:
- dependency-name: actions/checkout dependency-type: direct:production update-type: version-update:semver-minor ...