### PR TITLE
Make repo_name optional in deploy_app workflow

### DIFF
--- a/.github/workflows/deploy_app.yaml
+++ b/.github/workflows/deploy_app.yaml
@@ -8,10 +8,6 @@ on:
         description: 'Name of app to get current k8s deployment'
         required: true
         type: string
-      repo_name:
-        description: 'Name of app repo for Docker image'
-        required: true
-        type: string
       commit_id:
         description: 'HEAD commit hash'
         required: true
@@ -25,6 +21,11 @@ on:
         required: false
         default: true
         type: boolean
+      repo_name:
+        description: 'Name of app repo for Docker image'
+        required: false
+        default: ''
+        type: string
     secrets:
       creds:
         required: true

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
 ```
 
 ### Build and push a Docker image to GHCR
-This is useful for ensuring that an image exists before a deploy & migrate. This example will build on every pull request update, but this workflow can also be used as a part of larger deploy jobs to avoid excessive building. You can also optionally add the `latest` tag (defaults to false) if you're updating on push to master.
+This is useful for ensuring that an image exists before a deploy & migrate. This example will build on every pull request update, but this workflow can also be used as a part of larger deploy jobs to avoid excessive building. You can also optionally add the `latest` tag (defaults to false) if you're updating on push to master. Extra build arguments can be specified with `build-args`, sent as a string.
 
 ```yaml
 name: Build and Push Image
@@ -41,6 +41,8 @@ jobs:
       repo_name: education-api
       commit_id: ${{ github.sha }}
       latest: true
+      build-args: |
+        APP_ENV=staging
 ```
 
 ### Deploy a Rails app in Kubernetes

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
       repo_name: education-api
       commit_id: ${{ github.sha }}
       latest: true
-      build-args: |
+      build_args: |
         APP_ENV=staging
 ```
 


### PR DESCRIPTION
https://github.com/zooniverse/ci-cd/pull/44 is right, `repo_name` is never actually used in that action. Removing it from the list of arguments would cause all repos that currently send it to fail, so I'll make it optional and remove it from repos when possible.

Also adds sending build-args to the build/push workflow to the example in the README.