### PR TITLE
Update shared action versions

### DIFF
--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -59,7 +59,7 @@ jobs:
       run: echo ${{ inputs.commit_id }} > commit_id.txt
 
     - name: Build and push
-      uses: docker/build-push-action@5.1.0
+      uses: docker/build-push-action@v5.1.0
       with:
         context: .
         file: ${{ inputs.file }}

--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -33,19 +33,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v4.1.1
       with:
         repository: zooniverse/${{ inputs.repo_name }}
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3.0.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3.0.0
 
     - name: Create registry tags
       id: create_tags
@@ -59,7 +59,7 @@ jobs:
       run: echo ${{ inputs.commit_id }} > commit_id.txt
 
     - name: Build and push
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@5.1.0
       with:
         context: .
         file: ${{ inputs.file }}

--- a/.github/workflows/db_migration.yaml
+++ b/.github/workflows/db_migration.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v4.1.1
 
       - uses: azure/login@v1
         with:

--- a/.github/workflows/deploy_app.yaml
+++ b/.github/workflows/deploy_app.yaml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v4.1.1
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3.0.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/workflows/npm_build.yaml
+++ b/.github/workflows/npm_build.yaml
@@ -28,7 +28,7 @@ jobs:
     env:
       HEAD_COMMIT: ${{ inputs.commit_id }}
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@v4.1.1
 
     - name: Node.js build
       id: build

--- a/.github/workflows/run_rspec.yaml
+++ b/.github/workflows/run_rspec.yaml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v4.1.1
 
       - name: Check for focused specs
         run: ./scripts/no_focus.sh

--- a/.github/workflows/run_task.yaml
+++ b/.github/workflows/run_task.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v4.1.1
 
       - uses: azure/login@v1
         with:


### PR DESCRIPTION
Updates `actions/checkout`, and `docker/[build-push-image|action-login|setup-buildx-action]` in relevant actions.

The Dependabot PR for `actions/checkout@v4` kept failing the image push part of the tests with a github-side 503. The tests run fine on main, though, which is wild because there's no interface change afaik. Maybe updating these action versions at once (incl the apparently offending `build-push-action` will shake it loose. They all need it, anyway.