### PR TITLE
Update docker-build-push to v6

### DIFF
--- a/.github/workflows/build_and_push_image.yaml
+++ b/.github/workflows/build_and_push_image.yaml
@@ -59,7 +59,7 @@ jobs:
       run: echo ${{ inputs.commit_id }} > commit_id.txt
 
     - name: Build and push
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         context: .
         file: ${{ inputs.file }}


### PR DESCRIPTION
Version 6 is still kind of new, want to make sure these tests pass. 