### PR TITLE
Use more permissive login-action version

### DIFF
--- a/.github/workflows/deploy_app.yaml
+++ b/.github/workflows/deploy_app.yaml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3.0.0
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}


### PR DESCRIPTION
Allow docker-login to update to 3.3.0, up to <4. 