### PR TITLE
Add Purge Front Door Cache action

### DIFF
--- a/.github/workflows/purge_cache.yaml
+++ b/.github/workflows/purge_cache.yaml
@@ -1,0 +1,36 @@
+name: Purge Front Door Cache
+
+on:
+  # Run this workflow from other workflows
+  workflow_call:
+    inputs:
+      fdname:
+        description: 'Front Door Name'
+        required: true
+        type: string
+      path:
+        description: 'Content path to purge'
+        required: true
+        type: string
+    secrets:
+      creds:
+        required: true
+
+jobs:
+  purge_cache:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Log in
+      uses: azure/login@v2
+      with:
+        creds: ${{ secrets.creds }}
+
+    - name: Purge Cache Path
+      id: upload
+      uses: azure/CLI@v2
+      with:
+        inlineScript: |
+          az network front-door purge-endpoint \
+            --resource-group 'static-sites' \
+            --name '${{ inputs.fdname }}' \
+            --content-paths '${{ inputs.path }}'

--- a/.github/workflows/test_cache_purge.yaml
+++ b/.github/workflows/test_cache_purge.yaml
@@ -1,0 +1,15 @@
+name: Test Cache Purge
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test_cache_purge:
+    name: Purge cached file
+    uses: ./.github/workflows/purge_cache.yaml
+    with:
+      fdname: 'frontend-preview-zooniverse-org'
+      path: '/assets/star.jpg'
+    secrets:
+      creds: ${{ secrets.AZURE_AKS }}

--- a/.github/workflows/test_cache_purge.yaml
+++ b/.github/workflows/test_cache_purge.yaml
@@ -12,4 +12,4 @@ jobs:
       fdname: 'frontend-preview-zooniverse-org'
       path: '/assets/star.jpg'
     secrets:
-      creds: ${{ secrets.AZURE_AKS }}
+      creds: ${{ secrets.AZURE_STATIC_SITES }}

--- a/README.md
+++ b/README.md
@@ -96,6 +96,25 @@ jobs:
       creds: ${{ secrets.AZURE_STATIC_SITES }}
 ```
 
+### Purge the Front Door cache for a specific AFD instance and content path
+```yaml
+name: Purge Star
+on:
+  push:
+    tags:
+      - production-release
+
+jobs:
+  purge_cached_star:
+    name: Purge cached file
+    uses: zooniverse/ci-cd/.github/workflows/purge_cache.yaml@main
+    with:
+      fdname: 'frontend-preview-zooniverse-org'
+      path: '/assets/star.jpg'
+    secrets:
+      creds: ${{ secrets.AZURE_STATIC_SITES }}
+```
+
 ### Send a Slack notification
 ```yaml
 slack_notification:


### PR DESCRIPTION
Inputs are strings: the name of the Front Door (e.g. `www-zooniverse-org`) and the content path to purge (e.g. `/`, `/about/`, `/about/*`, etc). 

This starts with support for a single string and requires multiple calls to purge multiple paths. However, it is possible to pass a string that can be processed into a matrix strategy (like `"'/', '/*'"` or `"'/', '/about', '/get-involved'"`). I'm thinking that right now we might just process `'/*'` for the initial use case for this (post-FEM deploys) so I'll revisit if required.

Also includes a test that purges the cache for https://frontend.preview.zooniverse.org/assets/star.jpg 