### PR TITLE
Add delete web blobs action

### DIFF
--- a/.github/workflows/delete_blobs.yaml
+++ b/.github/workflows/delete_blobs.yaml
@@ -1,0 +1,32 @@
+name: Delete blob from web storage
+
+on:
+  # Run this workflow from other workflows
+  workflow_call:
+    inputs:
+      target:
+        description: 'Full path (minus container name) to target blob'
+        required: true
+        type: string
+    secrets:
+      creds:
+        required: true
+
+jobs:
+  delete_blobs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: azure/login@v2
+      with:
+        creds: ${{ secrets.creds }}
+
+    - name: Delete web blob recursively
+      id: delete
+      uses: azure/CLI@v2
+      with:
+        inlineScript: |
+          az storage blob delete-batch
+            --account-name zooniversestatic
+            --source '$web'
+            --pattern '${{ inputs.target }}/*'
+            --dryrun


### PR DESCRIPTION
Adds a new shared action to delete blobs from the `$web` container of the zooniversestatic storage account. PFE branch deploys just accumulated and were never cleaned up. This provides a means for staging deploys to clean up the associated branch deploy. The PFE staging deploy action will be amended to include running this action with the target of `preview.zooniverse.org/panoptes-front-end/pr-xxxx`. 

This includes the `--dryrun` flag to start with. The contents of the target blob won't be deleted but will be logged so that I can ensure that the path inputs to this action are correct. I'll remove the flag in a new PR.