### PR TITLE
Unpin az cli version

### DIFF
--- a/.github/workflows/deploy_static.yaml
+++ b/.github/workflows/deploy_static.yaml
@@ -14,7 +14,7 @@ on:
         type: string
       max_age:
         description: 'max-age for non-index.html files'
-        default: 604800
+        default: '604800'
         required: false
         type: string
     secrets:
@@ -38,7 +38,6 @@ jobs:
       id: upload
       uses: azure/CLI@v2
       with:
-        azcliversion: 2.33.1
         inlineScript: |
           az storage blob upload \
             --account-name zooniversestatic \

--- a/.github/workflows/deploy_static.yaml
+++ b/.github/workflows/deploy_static.yaml
@@ -42,6 +42,7 @@ jobs:
           az storage blob upload \
             --account-name zooniversestatic \
             --content-cache-control 'public, max-age=60' \
+            --overwrite \
             --container-name '$web' \
             --name '${{ inputs.target }}/index.html' \
             --file './index.html'
@@ -49,6 +50,7 @@ jobs:
           az storage blob upload \
             --account-name zooniversestatic \
             --content-cache-control 'public, max-age=60' \
+            --overwrite \
             --container-name '$web' \
             --name '${{ inputs.target }}/commit_id.txt' \
             --file './commit_id.txt'
@@ -56,5 +58,6 @@ jobs:
           az storage blob upload-batch \
             --account-name zooniversestatic \
             --content-cache-control 'public, immutable, max-age=${{ inputs.max_age }}' \
+            --overwrite \
             --destination '$web/${{ inputs.target }}' \
             --source ./


### PR DESCRIPTION
Azure CLI version in their GHA was pinned a long time ago in order to avoid some issues on their end. This should be solved and so we can use the latest az cli version. Also, the default upload behavior post-2.33 is different and now requires the `--overwrite` flag to be included.

Also in the deploy_static action, the max_age input should be a string as noted.