### PR TITLE
Pin azcli version to 2.76 to avoid bug

### DIFF
--- a/.github/workflows/delete_blobs.yaml
+++ b/.github/workflows/delete_blobs.yaml
@@ -24,7 +24,10 @@ jobs:
       id: delete
       uses: azure/CLI@v2
       with:
+        # Pin version due to bug: https://github.com/Azure/azure-cli/issues/32039
+        azcliversion: 2.76.0
         inlineScript: |
+          echo "Deleting blobs in path: ${{ inputs.target }}/*"
           az storage blob delete-batch \
             --account-name zooniversestatic \
             --source '$web' \


### PR DESCRIPTION
Blob deletion jobs were failing with an under-the-hood az CLI python TypeError exception. [This appears to be a bug](https://github.com/Azure/azure-cli/issues/32039) in the CLI version 2.77 and can be avoided until a fix is rolled out (allegedly middle of Oct) by pinning version 2.76. This isn't the first time I've had to pin a az CLI version due to a bug. 


