### PR TITLE
Print logs from first pod in in list in case multiple are returned

### DIFF
--- a/.github/workflows/db_migration.yaml
+++ b/.github/workflows/db_migration.yaml
@@ -61,7 +61,7 @@ jobs:
           echo "Job Description:"
           kubectl describe job/$JOB_NAME
           echo "Pod Logs:"
-          kubectl logs $(kubectl get pods --selector=job-name=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
+          kubectl logs $(kubectl get pods --selector=job-name=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}' | cut -d' ' -f1)
 
       - name: Clean up job if successful
         if: always()


### PR DESCRIPTION
When a job makes more than one attempt, more than one pod can be generated. So when the database migration workflow runs and fails, there are two pods returned by the `kubectl get pods` command. This causes an error when it tries to print the logs.

This PR splits the returned list and uses the first one. Since the logs are likely the same and are available via kubectl anyway, this is for convenience.